### PR TITLE
Implemented `uninstall` and `exec` subparsers, and made fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Pipenv files #
 ################
 Pipfile*
+print-files.sh
+*output.txt
+*.bak

--- a/README.md
+++ b/README.md
@@ -212,3 +212,6 @@ Scripts that one may want to execute on occasion and have immediate access to it
 
 ### Triggering scripts with OS events
 You may want to execute some scripts after a certain OS event occurs. This functionality will be added later to the `$CFG_FILE`.
+
+### Switch to JSON5 configuration files
+Configuration files will be parsed from files of the JSON5 format, a more user-friendly version of JSON. This will mark the 1.0.0 release.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,28 @@
 # fedorafig v0.2.0-alpha
-<img alt="version static badge" src="https://img.shields.io/badge/version-0.2.0-blue" height=25> <img alt="unlicense license static badge" src="https://img.shields.io/badge/license-Unlicense-red" height="25"> <img alt="issues static badge" src="https://img.shields.io/github/issues/andrei-murashev/fedorafig?color=yellow" height="25"> <img alt="stars" src="https://img.shields.io/github/stars/andrei-murashev/fedorafig?color=white" height="25">
+<img
+  alt="version static badge"
+  src="https://img.shields.io/badge/version-0.2.0-blue"
+  height=25>
+<img
+  alt="unlicense license static badge"
+  src="https://img.shields.io/badge/license-Unlicense-red"
+  height="25">
+<img
+  alt="issues static badge"
+  src="https://img.shields.io/github/issues/andrei-murashev/fedorafig?color=yellow"
+  height="25">
+<img
+  alt="stars"
+  src="https://img.shields.io/github/stars/andrei-murashev/fedorafig?color=white"
+  height="25">
 
-Have you ever had to go through the tedious task of writing your own configuration scripts for your Fedora Linux system? I have, and I didn't like it, which is why I made this utility for myself and perhaps it can help you too. `fedorafig` is a one-stop shop configuration utility for Fedora Linux. All you have to do is specify the configuration paths and their destinations, specify the packages, optionally from a specific repository, and any post-installation scripts.
+Have you ever had to go through the tedious task of writing your own
+configuration scripts for your Fedora Linux system? I have, and I didn't like
+it, which is why I made this utility for myself and perhaps it can help you too.
+`fedorafig` is a one-stop shop configuration utility for Fedora Linux. All you
+have to do is specify the configuration paths and their destinations, specify
+the packages, optionally from a specific repository, and any post-installation
+scripts.
 
 ## Installation
 In a directory where the path `fedorafig` does not yet exist, execute the following commands
@@ -11,13 +32,6 @@ cd fedorafig && chmod u+x install.sh && ./install.sh
 cd .. && rm -rf fedorafig
 ```
 
-## Uninstallation
-If you would like to uninstall this utility, simply download `uninstall.sh`, and run
-```bash
-chmod u+x uninstall.sh
-./uninstall.sh
-rm uninstall.sh
-```
 
 ## Quick guide
 This is a guide on how to use the utility with concrete examples.
@@ -46,7 +60,8 @@ Ensure `$CFG_DIR`, typically `~/.config/fedorafig/` looks like this:
   "_COMMENT": "Usually ~/.config/fedorafig/configs/"
 }
 ```
-Copies files from `cfgpath` (path relative to `configs/`) to `syspath` (evaluated absolute path).
+Copies files from `cfgpath` (path relative to `configs/`) to `syspath`
+(evaluated absolute path).
 
 **Install a package**
 ```json
@@ -106,12 +121,15 @@ All values with the key `"_COMMENT"` are ignored.
 Follow these steps to maintain a functional setup.
 
 **Prepare Directory**: Populate `configs/`, `repos/`, and `scripts/`. \
-**Create a JSON configuration file**: Write JSON entries for tasks that the utility will execute. \
+**Create a JSON configuration file**: Write JSON entries for tasks that the
+utility will execute. \
 **Run `check`**: Validate the configuration.
 
 ## Features
 ### Set utility configuration path
-By default, the `fedorafig` configuration directory is set to `~/.config/fedorafig`. If you wish to change it to `$CFG_DIR`, first ensure that the directory exists, then pass it to the utility with `-f` or `--new-cfg-dir`.
+By default, the `fedorafig` configuration directory is set to `~/.config/
+fedorafig`. If you wish to change it to `$CFG_DIR`, first ensure that the
+directory exists, then pass it to the utility with `-f` or `--new-cfg-dir`.
 ```bash
 mkdir -p $CFG_DIR
 fedorafig -f $CFG_DIR
@@ -124,14 +142,26 @@ fedorafig -f ~/.fedorafig
 ```
 
 ### Checking the configuration
-`check` looks at your configuration specified for the OS in a JSON file. To check the OS configuration `$CFG_FILE`, a JSON file, it must located with `$CFG_DIR`, and for `check` to run successfully, the following must be satisfied:
-+ In `$CFG_DIR`, there must be directories named `configs`, `repos`, and `scripts`.
+`check` looks at your configuration specified for the OS in a JSON file. To
+check the OS configuration `$CFG_FILE`, a JSON file, it must located with
+`$CFG_DIR`, and for `check` to run successfully, the following must be
+satisfied:
++ In `$CFG_DIR`, there must be directories named `configs`, `repos`, and
+`scripts`.
 + For each entry in `$CFG_FILE`, `syspath` and `cfgpath` must exist together.
-+ In `$CFG_FILE`, a specified `repo` subentry must exist in `$CFG_DIR/repos`, and be valid `.repo` file, ending in `.repo` in its name.
-+ In `$CFG_FILE`, all `package` subentries must exist in at least one repository specified in all `repo` subentries that are not accompanied by a `package` subentry (when `package` and `repo` are not in the same entry). If `package` and `repo` are found in the same entry, then that `package` is only required to exist in that `repo`.
-+ In `$CFG_FILE`, all `script` subentries must exist in `$CFG_DIR/scripts`, but not necessarily be valid. This is up to the user to ensure.
++ In `$CFG_FILE`, a specified `repo` subentry must exist in `$CFG_DIR/repos`,
+and be valid `.repo` file, ending in `.repo` in its name.
++ In `$CFG_FILE`, all `package` subentries must exist in at least one repository
+specified in all `repo` subentries that are not accompanied by a `package`
+subentry (when `package` and `repo` are not in the same entry). If `package` and
+`repo` are found in the same entry, then that `package` is only required to
+exist in that `repo`.
++ In `$CFG_FILE`, all `script` subentries must exist in `$CFG_DIR/scripts`, but
+not necessarily be valid. This is up to the user to ensure.
 
-Note this does not prevent all runtime errors, as the scripts specified may have raise runtime errors. The rest of the OS configuration will not raise runtime errors if `check` is successful.
+Note this does not prevent all runtime errors, as the scripts specified may have
+raise runtime errors. The rest of the OS configuration will not raise runtime
+errors if `check` is successful.
 
 Given that your `$CFG_DIR` looks like this:
 ```bash
@@ -162,13 +192,16 @@ Example:
 fedorafig check cfg1.json
 ```
 
-You can have as many JSON files to configure your OS as you want. Note that checksum are used to check if anything has changed to see whether check will need to be rerun. The following flags can be used for some extra options:
+You can have as many JSON files to configure your OS as you want. Note that
+checksum are used to check if anything has changed to see whether check will
+need to be rerun. The following flags can be used for some extra options:
 + `-c` or `--only-checksum`: Only calculate the checksum.
 + `-s` or `--show-checksum`: Show checksum after its calculated.
 + `-n` or `--no-checksum`: Does not calculate the potentially new checksum.
 
 ### Applying the configuration
-If you want to apply the configurations specified in the file `cfg1.json` and your directory structure looks like this:
+If you want to apply the configurations specified in the file `cfg1.json` and
+your directory structure looks like this:
 ```bash
 ~/.fedorafig
 ├── configs
@@ -179,36 +212,56 @@ If you want to apply the configurations specified in the file `cfg1.json` and yo
 ```
 
 Simply run: `fedorafig run cfg1.json` \
-There are also options to apply only parts of your configuration, none of which are mutually exclusive. The code for these is also run for each flag is also run in this order, descending:
-+ `-r` or `--repos-include`: Copies all repos to `/etc/yum/repos.d/` that aren't accompanied by a `pkg` subentry, and enables them.
-+ `-p` or `--pkgs-include`: Installs all packages specified in the configuration, and if there are `pkg` subentries without `repo` subentries, then the flag `-r` is automatically applied.
-+ `-f` or `--files-include`: Copies the contents in `cfgpath` to `syspath`. The directory specified in the `cfgpath` subentry is not itself copied, only its contents are.
-+ `-s` or `--script-include`: For every single specified script, it enables execution permissions for your user and executes them.
+There are also options to apply only parts of your configuration, none of which
+are mutually exclusive. The code for these is also run for each flag is also run
+in this order, descending:
++ `-r` or `--repos-include`: Copies all repos to `/etc/yum/repos.d/` that aren't
+accompanied by a `pkg` subentry, and enables them.
++ `-p` or `--pkgs-include`: Installs all packages specified in the 
+configuration, and if there are `pkg` subentries without `repo` subentries, then
+the flag `-r` is automatically applied.
++ `-f` or `--files-include`: Copies the contents in `cfgpath` to `syspath`. The
+directory specified in the `cfgpath` subentry is not itself copied, only its
+contents are.
++ `-s` or `--script-include`: For every single specified script, it enables
+execution permissions for your user and executes them.
 
-Using these flags doesn't "include" anything extra. It simply means that you start with nothing included in your application of the configuration when you start using the flags, and then the flags include specifically what you want.
+Using these flags doesn't "include" anything extra. It simply means that you
+start with nothing included in your application of the configuration when you
+start using the flags, and then the flags include specifically what you want.
+
+### Access commonly-used scripts
+If your script is called `$SCRIPT`, make sure it resides in `$CFG_DIR/common/`.
+Then, running `fedorafig exec $SCRIPT` will run that script.
 
 ### Uninstalling
 Simply run: `fedorafig uninstall` \
-Optionally you can pass the flags `-c` or `--with-config` to also remove the current configuration directory of the utility, and the flags `-s` `--with-state` to also remove the state directory.
+Optionally you can pass the flags `-c` or `--with-config` to also remove the
+current configuration directory of the utility, and the flags `-s` or 
+`--with-state` to also remove the state directory.
 
 ## Coming features
 ### Support for multiple subentries
-+ `repo` subentries: Multiple `repo` subentries will indicate that the listed repos are for successive fallback.
-+ `pkgs` subentries: Multiple `pkgs` are installed. If even one repository is specified, the utility attempts to install all of them from it.
-+ `syspath` and `cfgpath` subentries: All contents in the `cfgpath` subentries are copied to all `syspath` subentries.
++ `repo` subentries: Multiple `repo` subentries will indicate that the listed
+repos are for successive fallback.
++ `pkgs` subentries: Multiple `pkgs` are installed. If even one repository is
+specified, the utility attempts to install all of them from it.
++ `syspath` and `cfgpath` subentries: All contents in the `cfgpath` subentries
+are copied to all `syspath` subentries.
 + `script` subentries: Just runs all the scripts specified in the entry in order.
 
 ### Silent output
-No output is printed to `stdout` when the utility is running. Can be specified with `-q` or `--quiet`
+No output is printed to `stdout` when the utility is running. Can be specified
+with `-q` or `--quiet`
 
 ### Verbose output
-Very detailed output is printed to `stdout` when the utility is running. Can be specified with `-v` or `--verbose`
-
-### Access to commonly-used scripts
-Scripts that one may want to execute on occasion and have immediate access to it can be executed with `fedorafig exec $SCRIPT`. All instances of `$SCRIPT` will be stored in `$CFG_DIR/common-scripts`.
+Very detailed output is printed to `stdout` when the utility is running. Can be
+specified with `-v` or `--verbose`
 
 ### Triggering scripts with OS events
-You may want to execute some scripts after a certain OS event occurs. This functionality will be added later to the `$CFG_FILE`.
+You may want to execute some scripts after a certain OS event occurs. This
+functionality will be added later to the `$CFG_FILE`.
 
 ### Switch to JSON5 configuration files
-Configuration files will be parsed from files of the JSON5 format, a more user-friendly version of JSON. This will mark the 1.0.0 release.
+Configuration files will be parsed from files of the JSON5 format, a more user-
+friendly version of JSON. This will mark the 1.0.0 release.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fedorafig v0.2.0-alpha
 <img alt="version static badge" src="https://img.shields.io/badge/version-0.2.0-blue" height=25> <img alt="unlicense license static badge" src="https://img.shields.io/badge/license-Unlicense-red" height="25"> <img alt="issues static badge" src="https://img.shields.io/github/issues/andrei-murashev/fedorafig?color=yellow" height="25"> <img alt="stars" src="https://img.shields.io/github/stars/andrei-murashev/fedorafig?color=white" height="25">
 
-Have you ever had to go through the tedious task of writing your own configuration scripts for you Fedora Linux system? I have, and I didn't like it, which is why I made this utility for myself and perhaps it can help you too. `fedorafig` is a one-stop shop configuration utility for Fedora Linux. All you have to do is specify the configuration paths and their destinations, specify the packages, optionally from a specific repository, and any post-installation scripts.
+Have you ever had to go through the tedious task of writing your own configuration scripts for your Fedora Linux system? I have, and I didn't like it, which is why I made this utility for myself and perhaps it can help you too. `fedorafig` is a one-stop shop configuration utility for Fedora Linux. All you have to do is specify the configuration paths and their destinations, specify the packages, optionally from a specific repository, and any post-installation scripts.
 
 ## Installation
 In a directory where the path `fedorafig` does not yet exist, execute the following commands

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # fedorafig v0.2.0-alpha
-<img alt="version static badge" src="https://img.shields.io/badge/version-0.1.0-blue" height=25> <img alt="unlicense license static badge" src="https://img.shields.io/badge/license-Unlicense-red" height="25"> <img alt="issues static badge" src="https://img.shields.io/github/issues/andrei-murashev/fedorafig?color=yellow" height="25"> <img alt="stars" src="https://img.shields.io/github/stars/andrei-murashev/fedorafig?color=white" height="25">
+<img alt="version static badge" src="https://img.shields.io/badge/version-0.2.0-blue" height=25> <img alt="unlicense license static badge" src="https://img.shields.io/badge/license-Unlicense-red" height="25"> <img alt="issues static badge" src="https://img.shields.io/github/issues/andrei-murashev/fedorafig?color=yellow" height="25"> <img alt="stars" src="https://img.shields.io/github/stars/andrei-murashev/fedorafig?color=white" height="25">
 
 Have you ever had to go through the tedious task of writing your own configuration scripts for you Fedora Linux system? I have, and I didn't like it, which is why I made this utility for myself and perhaps it can help you too. `fedorafig` is a one-stop shop configuration utility for Fedora Linux. All you have to do is specify the configuration paths and their destinations, specify the packages, optionally from a specific repository, and any post-installation scripts.
 
@@ -197,9 +197,6 @@ Optionally you can pass the flags `-c` or `--with-config` to also remove the cur
 + `pkgs` subentries: Multiple `pkgs` are installed. If even one repository is specified, the utility attempts to install all of them from it.
 + `syspath` and `cfgpath` subentries: All contents in the `cfgpath` subentries are copied to all `syspath` subentries.
 + `script` subentries: Just runs all the scripts specified in the entry in order.
-
-### Support for different shells
-You will be able to specify which scripts are run with what shell. You can make a `shell` subentry above some `script` subentries, and the following scripts will be executed with that shell, unless the shell is respecified, in which case the scripts succeeding the respecification are run with the respecified shell.
 
 ### Silent output
 No output is printed to `stdout` when the utility is running. Can be specified with `-q` or `--quiet`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# fedorafig v0.2.0-alpha
+# fedorafig v0.3.0-alpha
 <img
   alt="version static badge"
-  src="https://img.shields.io/badge/version-0.2.0-blue"
+  src="https://img.shields.io/badge/version-0.3.0-blue"
   height=25>
 <img
   alt="unlicense license static badge"

--- a/README.md
+++ b/README.md
@@ -258,10 +258,6 @@ with `-q` or `--quiet`
 Very detailed output is printed to `stdout` when the utility is running. Can be
 specified with `-v` or `--verbose`
 
-### Triggering scripts with OS events
-You may want to execute some scripts after a certain OS event occurs. This
-functionality will be added later to the `$CFG_FILE`.
-
 ### Switch to JSON5 configuration files
 Configuration files will be parsed from files of the JSON5 format, a more user-
 friendly version of JSON. This will mark the 1.0.0 release.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ There are also options to apply only parts of your configuration, none of which 
 
 Using these flags doesn't "include" anything extra. It simply means that you start with nothing included in your application of the configuration when you start using the flags, and then the flags include specifically what you want.
 
+### Uninstalling
+Simply run: `fedorafig uninstall` \
+Optionally you can pass the flags `-c` or `--with-config` to also remove the current configuration directory of the utility, and the flags `-s` `--with-state` to also remove the state directory.
 
 ## Coming features
 ### Support for multiple subentries
@@ -194,9 +197,6 @@ Using these flags doesn't "include" anything extra. It simply means that you sta
 + `pkgs` subentries: Multiple `pkgs` are installed. If even one repository is specified, the utility attempts to install all of them from it.
 + `syspath` and `cfgpath` subentries: All contents in the `cfgpath` subentries are copied to all `syspath` subentries.
 + `script` subentries: Just runs all the scripts specified in the entry in order.
-
-### Self-uninstall
-Uninstalls itself. You will also be able to specify to remove the configuration directory.
 
 ### Support for different shells
 You will be able to specify which scripts are run with what shell. You can make a `shell` subentry above some `script` subentries, and the following scripts will be executed with that shell, unless the shell is respecified, in which case the scripts succeeding the respecification are run with the respecified shell.

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,22 +1,3 @@
-STATUS: Unresolved.
---- Instead of making the user choose the repo by name, they should choose by 
-    repo file name, as the real repo name is specified in the repo file.
-    The reason specifying the repo name works right now is because I have, in
-    my configs, assumed that the repo name is what is the name of the repo
-    file without the `.repo`. But I am wrong. That is only the base file
-    name, not the repo name. Getting the repo name would require iterating
-    over the repo file until the name is found.
-
-STATUS: Resolved. Not applied.
---- Moving repos into `/tmp/fedorafig/` is NOT redundant because sometimes you
-    want to activate all part of the repositories, but if you select the
-    `reposdir` to be the `repos` directory, then all repos that could
-    possibly be used will be used. However, IT IS redundant to move all the
-    repo file to `/tmp/fedorafig/` when `all` repos are specified, because
-    only then can you specify that the `reposdir` should be `repos`. But this requires extra code, but in this code extra code is better because it
-    results in less disk operations, resulting in a faster program. Many repos
-    too actually, where extra repos can be used as fallback repos.
-
 STATUS: Resolved. Not applied.
 --- Currently, you can only add one of each subkey to each entry. There should
     be an option to specify multiple packages, syspaths, and scripts. Multiple
@@ -25,5 +6,7 @@ STATUS: Resolved. Not applied.
     into multiple directories if needed. Multiple scripts, for the same reason
     as multiple packages per entry.
 
-STATUS: Unresolved.
---- Code appears to be poorly written. I do not like its appearance and patterns.
+STATUS: Resolved. Not applied.
+--- Multiple copy paths
+    Paths should come in pairs and pairs of list. There will be subentries `copy`
+    for just pairs and `copy-many` for a pair of lists.

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 
 trap 'exit' INT
 
-mkdir -p ~/.config/fedorafig/ ~/.local/bin/
-mkdir -p ~/.local/state/fedorafig/ ~/.local/lib/fedorafig/
+source <(python3 src/cfg.py)
+mkdir -p "$CFG_DIR" "$PROG_DIR" "$EXEC_DIR" "$STATE_DIR"
 chmod u+x src/main.py
-cp -rf src/. ~/.local/lib/fedorafig/
-ln -s ~/.local/lib/fedorafig/main.py ~/.local/bin/fedorafig
+cp -rf src/. "$PROG_DIR"
+ln -s "$PROG_DIR"/main.py "$EXEC_DIR"/fedorafig

--- a/src/cfg.py
+++ b/src/cfg.py
@@ -1,18 +1,67 @@
+# System imports
 import os
 import time
 import subprocess
 
-def getpath(path):
-  return os.path.realpath(os.path.abspath(os.path.expanduser(path)))
+# Local imports
+import errors
+
+
+def resolve_path(path):
+  try: path = os.path.realpath(os.path.abspath(os.path.expanduser(path)))
+  except Exception as e: raise errors.FedorafigException(
+    "Unable to resolve path", path, exc=e)
+  return path
+
+# Path constants
+CFG_DIR = resolve_path('~/.config/fedorafig')
+LIB_DIR = resolve_path('~/.local/lib/fedorafig')
+STATE_DIR = resolve_path('~/.local/state/fedorafig')
+
+CFGS_DIR = os.path.join(CFG_DIR, 'configs')
+REPOS_DIR = os.path.join(CFG_DIR, 'repos')
+SCRIPTS_DIR = os.path.join(CFG_DIR, 'scripts')
+STATE_FILE = os.path.join(STATE_DIR, 'config.txt')
+
 
 def sudo_refresh():
-  try:
-    while True:
-      subprocess.run(['sudo', '-v'], check=True)
-      time.sleep(60)
-  except Exception:
-    raise Exception("Could not validate sudo password")
-    # TODO: raise this exception to argparse.
+  while True:
+    try: subprocess.run(['sudo', '-v'], check=True)
+    except subprocess.CalledSubprocessError as e:
+      raise errors.FedorafigException('', exc=e) # TODO
+    time.sleep(60)
 
-CFG_DIR_REL = f'/home/{os.environ.get('USER')}/.config/fedorafig'
-CFG_DIR = getpath(CFG_DIR_REL)
+
+def makedirs_if_need(dpath):
+  try: os.makedirs(dpath, exist_ok=True)
+  except Exception as e: raise errors.FedorafigException(
+    "Unable to make directory and its parents", dpath, exc=e)
+
+
+def set_cfg_dir(dpath):
+  if not os.path.isdir(resolve_path(dpath)):
+    raise errors.FedorafigException("Directory not found", dpath)
+
+  with open(STATE_FILE, 'w') as fh: fh.write(dpath)
+
+  import inspect
+  frame = inspect.currentframe().f_back
+  caller_file = frame.f_code.co_filename
+  if os.path.basename(caller_file) == 'argparse.py': return dpath
+
+
+def get_cfg_dir(dpath):
+  if not os.path.isfile(STATE_FILE): return
+
+  global CFG_DIR
+  with open(STATE_FILE, 'r') as fh: CFG_DIR = fh.readline().strip()
+
+
+get_cfg_dir(CFG_DIR)
+DIRS = [CFG_DIR, LIB_DIR, STATE_DIR]
+for dir in DIRS: makedirs_if_need(dir)
+
+# Constants for later use
+REPOS_N_PKGS = []
+SYS_N_CFG_DIRS = []
+SCRIPT_FILES = []

--- a/src/cfg.py
+++ b/src/cfg.py
@@ -39,7 +39,7 @@ def sudo_refresh():
   while True:
     try: subprocess.run(['sudo', '-v'], check=True)
     except subprocess.CalledSubprocessError as e:
-      raise errors.FedorafigException('', exc=e) # TODO
+      raise errors.FedorafigException('unable to validate sudo', exc=e) # TODO
     time.sleep(60)
 
 

--- a/src/cfg.py
+++ b/src/cfg.py
@@ -31,6 +31,7 @@ if sys.argv[0] == 'src/cfg.py':
 CFGS_DIR = os.path.join(CFG_DIR, 'configs')
 REPOS_DIR = os.path.join(CFG_DIR, 'repos')
 SCRIPTS_DIR = os.path.join(CFG_DIR, 'scripts')
+COMMON_DIR = os.path.join(CFG_DIR, 'common')
 STATE_FILE = os.path.join(STATE_DIR, 'config.txt')
 
 

--- a/src/cfg.py
+++ b/src/cfg.py
@@ -1,5 +1,6 @@
 # System imports
 import os
+import sys
 import time
 import subprocess
 
@@ -15,8 +16,17 @@ def resolve_path(path):
 
 # Path constants
 CFG_DIR = resolve_path('~/.config/fedorafig')
-LIB_DIR = resolve_path('~/.local/lib/fedorafig')
+PROG_DIR = resolve_path('~/.local/lib/fedorafig')
+EXEC_DIR = resolve_path('~/.local/bin/')
 STATE_DIR = resolve_path('~/.local/state/fedorafig')
+
+if sys.argv[0] == 'src/cfg.py':
+  os.environ['CFG_DIR'] = CFG_DIR
+  os.environ['PROG_DIR'] = PROG_DIR
+  os.environ['EXEC_DIR'] = EXEC_DIR
+  os.environ['STATE_DIR'] = STATE_DIR
+  for key, val in os.environ.items():
+    print(f"export {key}={val}")
 
 CFGS_DIR = os.path.join(CFG_DIR, 'configs')
 REPOS_DIR = os.path.join(CFG_DIR, 'repos')
@@ -57,11 +67,8 @@ def get_cfg_dir(dpath):
   with open(STATE_FILE, 'r') as fh: CFG_DIR = fh.readline().strip()
 
 
-get_cfg_dir(CFG_DIR)
-DIRS = [CFG_DIR, LIB_DIR, STATE_DIR]
-for dir in DIRS: makedirs_if_need(dir)
-
 # Constants for later use
+get_cfg_dir(CFG_DIR)
 REPOS_N_PKGS = []
 SYS_N_CFG_DIRS = []
 SCRIPT_FILES = []

--- a/src/check.py
+++ b/src/check.py
@@ -1,5 +1,6 @@
-# System packages
+# System imports
 import os
+import sys
 import json
 import glob
 import hashlib
@@ -7,89 +8,82 @@ import subprocess
 
 # Local packages
 import cfg
-from errors import CheckException
+import errors
+
+# NOTE:
+# I have decided that the `repo` entry must be the actual name of the repos-
+# itroy, not the name of the repo files. The repos that will be initially
+# enabled will be ones specified in `repos`. It is the user's responsibility
+# to understand their `.repo` files.
 
 
 class Check():
-  def __init__(self, arg_list):
-    self.args = vars(arg_list)
-    self.checksum = ''
+  def __init__(self, args):
+    self.args = args
+    self.checksum = None
+    self.file = args['CFG_FILE']
 
-    if not self.args['keep_checksums']: self.__delete_checksums()
-    # TODO: Consider whether this option is redundant ^.
-    if not self.args['only_checksum']: self.__check_syntax()
+    fpath = os.path.join(cfg.CFG_DIR, self.file)
+    if not os.path.isfile(fpath): raise errors.FedorafigException(
+      "File not found", fpath)
+    with open(os.path.join(cfg.CFG_DIR, self.file)) as fh:
+      self.data = json.load(fh)
 
-    if not self.args['no_checksum']: 
-      self.checksum = self.calc_checksum(self.args['CFG_FILE'])
+    # if you are performing `run` without checking, you just need to
+    # collect all the values
+    if sys.argv[1] == 'run': self.__check_syntax(collect_only=True); return
+
+    # Check that there are no contradicting options
+    checksum_yes \
+      = {key: args[key] for key in ['only_checksum', 'show_checksum']}
+    checksum_no \
+      = {key: args[key] for key in ['no_checksum']}
+
+    tmp_args \
+      = [key for key, val in (checksum_yes | checksum_no).items() if val]
+    dict_disj = lambda bool_dict: True in bool_dict.values()
+
+    if dict_disj(checksum_yes) and dict_disj(checksum_no):
+      tmp_args = [f'--{arg.replace('_', '-')}' for arg in tmp_args]
+      raise errors.FedorafigException("Conflicting options", *tmp_args)
+
+    # Run the actual checking
+    if not args['keep_checksums']: self.__delete_checksums()
+    if not args['only_checksum']: self.__check_syntax()
+    if not args['no_checksum']:
+      self.checksum = self.calc_checksum(self.file)
       self.__save_checksum()
-
-    if self.args['show_checksum']:
-      print(f"{self.args['CFG_FILE']} checksum: {self.checksum}")
+    if args['show_checksum']:
+      print(f"{self.file} checksum: {self.checksum}")
 
 
   def __delete_checksums(self):
-    state_dir = os.path.expanduser('~/.local/state/fedorafig')
+    matches = glob.glob(os.path.join(cfg.STATE_DIR, '*.sha256'))
 
-    try:
-      os.makedirs(state_dir, exist_ok=True)
-    except Exception:
-      raise CheckException(f"Cannot make state directory: {state_dir}")
-
-    pattern = '*.sha256'
-    matches = glob.glob(f'{state_dir}/{pattern}')
-    
     for match in matches:
       try: os.remove(match)
-      except PermissionError:
-        raise CheckException(f"No permission to remove file: {match}")
-      except IsADirectoryError:
-        raise CheckException(f"Cannot remove a directory: {match}")
-      except OSError:
-        raise CheckException(f"OS error prevents from deletion: {match}")
+      except Exception as e: raise errors.FedorafigException(
+        "Unable to remove checksum file", match, exc=e)
 
 
-  def __check_syntax(self):
-    fpath = os.path.join(cfg.CFG_DIR, self.args['CFG_FILE'])
-    if not (os.path.exists(fpath) and os.path.isfile(fpath)):
-      raise CheckException(
-        f"Configuration not found: {fpath}")
-    
-    data = None
-    with open(fpath, 'r') as fh:
-      data = json.load(fh)
+  def __check_syntax(self, collect_only=False):
+    # Collecting items for checking
+    for key, entry in self.data.items():
+      if key == '_COMMENT': continue
 
-    repos_n_pkgs = []
+      if not isinstance(entry, dict): raise errors.FedorafigException(
+        "Entry is not a JSON object", entry)
 
-    for key, entry in data.items():
-      if key == '_COMMENT':
-        continue
-
-      if not isinstance(entry, dict):
-        raise CheckException(f"Value is not an object for key: {key}")
-      
-      found_syspath = False
-      found_cfgpath = False
-      pkg = ''
-      repo = ''
+      cfgpath, syspath, pkg, repo, script = None, None, None, None, None
 
       for subkey, subentry in entry.items():
-        if subkey == '_COMMENT':
-          continue
-
+        if subkey == '_COMMENT': continue
+        
         elif subkey == 'syspath':
-          found_syspath = True
-          syspath = cfg.getpath(subentry)
-          if not os.path.exists(syspath):
-            try: os.makedirs(syspath)
-            except Exception: raise CheckException(
-              f"syspath could not be created: {syspath}")
+          syspath = cfg.resolve_path(subentry)
 
         elif subkey == 'cfgpath':
-          found_cfgpath = True
-          cfgpath = cfg.getpath(os.path.join(cfg.CFG_DIR, 'configs', subentry))
-          if not os.path.exists(cfgpath):
-            raise CheckException(
-              f"cfgpath does not exists or is not a file: {cfgpath}")
+          cfgpath = os.path.join(cfg.CFGS_DIR, subentry)
 
         elif subkey == 'repo':
           repo = subentry
@@ -98,91 +92,93 @@ class Check():
           pkg = subentry
 
         elif subkey == 'script':
-          script_path = cfg.getpath(os.path.join(cfg.CFG_DIR, 'scripts',
-            subentry))
-          if not (os.path.exists(script_path) and os.path.isfile(script_path)):
-            raise CheckException(f"Script not found: {script_path}")
+          script = os.path.join(cfg.SCRIPTS_DIR, subentry)
 
-        else:
-          raise CheckException(f"Subkey not recogised: {subkey}")
+        else: raise errors.FedorafigException("Invalid key found", subkey)
 
-      if repo or pkg: repos_n_pkgs.append((repo, pkg))
+      if repo or pkg: cfg.REPOS_N_PKGS.append((repo, pkg))
+      if syspath or cfgpath: cfg.SYS_N_CFG_DIRS.append((syspath, cfgpath))
+      if script: cfg.SCRIPT_FILES.append(script)
+    
+    # Checking existence of paths
+    if collect_only: return
 
-      if found_syspath != found_cfgpath:
-        raise CheckException("syspath and cfgpath do not accompany each other")
+    for syspath, cfgpath in cfg.SYS_N_CFG_DIRS:
+      if not os.path.isdir(cfgpath):
+        raise errors.FedorafigException("cfgpath not found", syspath)
 
-    tmp_repos_dir = '/tmp/fedorafig_repos'
-    if os.path.exists(tmp_repos_dir):
-      subprocess.run(['rm', '-rf', tmp_repos_dir], check=True)
-    os.mkdir(tmp_repos_dir)
+      if not os.path.isdir(syspath):
+        try: os.makedirs(syspath, exist_ok=True)
+        except Exception as e: raise errors.FedorafigException(
+          "Unable to find directory or make it and its parents",
+          syspath, exc=e)
 
-    # TODO: Maybe using `/tmp/fedorafig_repos` is redundant?
-    for repo, pkg in repos_n_pkgs:
-      if repo == 'all':
-        repo_paths = os.path.join(cfg.CFG_DIR, 'repos/*')
-        for path in glob.glob(repo_paths):
-          if os.path.isfile(path):
-            subprocess.run(['cp', path, '/tmp/fedorafig_repos'], check=True)
-        break
+      if not (bool(syspath) == bool(cfgpath)): raise errors.FedorafigException(
+        "syspath and cfgpath were not found together", syspath, cfgpath)
 
-      elif repo and not pkg:
-        print("REPO AND NOT PKG:", repo)
-        path = os.path.join(cfg.CFG_DIR, 'repos', f'{repo}.repo')
-        if not os.path.isfile(path):
-          raise CheckException(f"Unable to get to find repo file: {path}")
-        subprocess.run(['cp', path, '/tmp/fedorafig_repos'], check=True)
+    for script in cfg.SCRIPT_FILES:
+      if not os.path.isfile(script): raise errors.FedorafigException(
+        "script not found", script)
 
-    try:
-      subprocess.run(['dnf', '--setopt=reposdir=/tmp/fedorafig_repos', \
-        'repolist'], check=True, stderr=subprocess.PIPE, text=True)
-    except subprocess.CalledProcessError as e:
-      raise CheckException(e.stderr.strip())
+    # Checking existence of repos and packages
+    cmd = ['dnf', f'--setopt=reposdir={cfg.REPOS_DIR}', 'repolist', 'all']
+    try: out = subprocess.run(cmd, text=True, check=True,
+      stdout=subprocess.PIPE)
+    except subprocess.CalledProcessError as e: raise errors.FedorafigException(
+      ".repo file incorrectly formatted", exc=e)
 
-    for repo, pkg in repos_n_pkgs:
-      if pkg and not repo:
-        try: subprocess.run(['dnf', '--setopt=reposdir=/tmp/fedorafig_repos', \
-          'info', pkg], check=True)
-        except subprocess.CalledProcessError: raise CheckException(
-          f"Unable to find package: {pkg}")
+    cmd = ['awk', '{print $1}']
+    out = subprocess.run(cmd, text=True, input=out.stdout, check=True, 
+      stdout=subprocess.PIPE)
+    cmd = ['tail', '-n', '+2']
+    out = subprocess.run(cmd, text=True, input=out.stdout, check=True, 
+      stdout=subprocess.PIPE)
+
+    if not (repos := out.stdout.splitlines()): raise errors.FedorafigException(
+      "No repos found")
+
+    for repo, pkg in cfg.REPOS_N_PKGS:
+      if repo == 'all': continue
+
+      elif repo and repo not in repos: raise errors.FedorafigException(
+        "repo does not exist", repo)
+
+      elif pkg and not repo:
+        try: subprocess.run(['dnf', f'--setopt=reposdir={cfg.REPOS_DIR}',
+          'repoquery', pkg], check=True, stderr=subprocess.PIPE, text=True)
+        except subprocess.CalledProcessError: raise errors.FedorafigException(
+          "Unable to find package", pkg)
 
       elif pkg and repo:
-        try:
-          subprocess.run(['dnf', '--setopt=reposdir=/tmp/fedorafig_repos', \
-            f'--enablerepo={repo}', 'info', pkg], check=True)
-        except subprocess.CalledProcessError:
-          raise CheckException(
-            f"Unable to get package from repo: {pkg} from {repo}")
+        try: subprocess.run([
+          'dnf', f'--setopt=reposdir={cfg.REPOS_DIR}',
+          'repoquery', f'--repo={repo}', pkg],
+          check=True, stderr=subprocess.PIPE, text=True)
+        except subprocess.CalledProcessError as e:
+          raise errors.FedorafigException(
+            "Unable to find package from repo", pkg, repo)
 
 
   @staticmethod
   def calc_checksum(cfg_file):
     hasher = hashlib.sha256()
-
-    dpaths = [
-      os.path.join(cfg.CFG_DIR, 'repos'),
-      os.path.join(cfg.CFG_DIR, 'configs'),
-      os.path.join(cfg.CFG_DIR, 'scripts')
-    ]
+    dpaths = [cfg.CFGS_DIR, cfg.REPOS_DIR, cfg.SCRIPTS_DIR]
 
     for dpath in dpaths:
       for root, _, files in os.walk(dpath):
         for file in sorted(files):
           path = os.path.join(root, file)
           with open(path, 'rb') as fh:
-            while chunk := fh.read(8192):
-              hasher.update(chunk)
-
+            while chunk := fh.read(8192): hasher.update(chunk)
+    
     fpath = os.path.join(cfg.CFG_DIR, cfg_file)
     with open(fpath, 'rb') as fh:
-      while chunk := fh.read(8192):
-        hasher.update(chunk)
+      while chunk := fh.read(8192): hasher.update(chunk)
 
     return hasher.hexdigest()
 
 
   def __save_checksum(self):
-    name = self.args['CFG_FILE'] + '.sha256'
-    hash_fpath = os.path.join(cfg.getpath('~/.local/state/fedorafig'), name)
-
-    with open(hash_fpath, 'w') as fh:
-      fh.write(self.checksum)
+    fname = f'{self.file}.sha256'
+    hash_fpath = os.path.join(cfg.STATE_DIR, fname)
+    with open(hash_fpath, 'w') as fh: fh.write(self.checksum)

--- a/src/errors.py
+++ b/src/errors.py
@@ -15,6 +15,7 @@ class FedorafigException(Exception):
     if exc is None:
       super().__init__(msg);
     else:
+      print(msg)
       if isinstance(exc, SystemExit): traceback.print_exception(
         type(exc), exc, exc.__traceback__)
       else: raise exc

--- a/src/errors.py
+++ b/src/errors.py
@@ -1,15 +1,42 @@
-def exit1(msg):
-  print(msg)
-  exit(1)
+# System imports
+import os
+import logging
+import traceback
+
+# Local imports
+import help
 
 
-"""Exceptions that are used to let `argparse` know that it should exit with an 
-error, instead of `python3`, and traceback will be shown."""
+"""When raising this exception, this utility will exit gracefully and display
+any error info to the user."""
+class FedorafigException(Exception):
+  def __init__(self, msg, *pargs, args=None, exc=None):
+    print("FedorafigException raised", flush=True)
+    if exc is None:
+      super().__init__(msg);
+    else:
+      if isinstance(exc, SystemExit): traceback.print_exception(
+        type(exc), exc, exc.__traceback__)
+      else: raise exc
 
-class CheckException(Exception):
-  """Used for when checking the configuration directory and file syntax."""
-  pass
 
-class RunException(Exception):
-  """Used for when applying the configuration."""
-  pass
+  @staticmethod
+  def format(args, exc):
+    pass
+
+
+
+LOG = None
+def log(exc):
+  global LOG
+  from cfg import STATE_DIR
+  if LOG is None: LOG = os.path.join(STATE_DIR, 'log.txt')
+
+  logging.basicConfig(
+    filename=LOG,
+    level=logging.ERROR,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+  )
+
+  logging.error(str(exc), exc_info=exc)
+  print('fedorafig:', "Unknown error:", str(exc))

--- a/src/help.py
+++ b/src/help.py
@@ -1,0 +1,1 @@
+REPORT_ISSUE = "Please open an issue on GitHub" # TODO: Improve

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,21 @@ def main():
   parser_main.add_argument(
     '-c', '--set-cfg-dir',
     type=cfg.set_cfg_dir,
-    # default='~/.config/fedorafig',
+    action='store',
+    help="" # TODO
+  )
+
+  parser_main.add_argument(
+    '-q', '--quiet',
+    action='store_true',
+    default=False,
+    help="" # TODO
+  )
+
+  parser_main.add_argument(
+    '-v', '--verbose',
+    action='store_true',
+    default=False,
     help="" # TODO
   )
 
@@ -44,6 +58,8 @@ def main():
 
   parser_check.add_argument(
     'CFG_FILE',
+    action='store',
+    default=None,
     help="" # TODO
   )
 
@@ -85,6 +101,8 @@ def main():
 
   parser_run.add_argument(
     'CFG_FILE',
+    action='store',
+    default=None,
     help="" # TODO
   )
 
@@ -113,6 +131,21 @@ def main():
     '-s', '--scripts-include',
     action='store_true',
     default=False,
+    help="" # TODO
+  )
+
+  """============================= EXEC PARSER ============================"""
+  parser_exec = subparsers.add_parser(
+    'exec',
+    usage='', # TODO
+    help="" # TODO
+  )
+  parser_exec.set_defaults(func=exec)
+
+  parser_exec.add_argument(
+    'SCRIPT_NAME',
+    action='store',
+    default=None,
     help="" # TODO
   )
 
@@ -167,6 +200,18 @@ def run(args):
   try: Run(args)
   except errors.FedorafigException as e: raise
   except (Exception, SystemExit) as e: errors.log(e); print(help.REPORT_ISSUE)
+
+
+def exec(args):
+  name = args['SCRIPT_NAME']
+  path = os.path.join(cfg.COMMON_DIR, name)
+  if not os.path.isfile(path): raise errors.FedorafigException(
+    "script not found", path)
+  
+  from subprocess import run, CalledProcessError
+  run(['chmod', 'u+x', path], check=True)
+  try: run([path], check=True)
+  except CalledProcessError as e: print(e)
 
 
 def uninstall(args):

--- a/src/main.py
+++ b/src/main.py
@@ -23,7 +23,7 @@ def main():
   )
 
   parser_main.add_argument(
-    '-f', '--set-cfg-dir',
+    '-c', '--set-cfg-dir',
     type=cfg.set_cfg_dir,
     # default='~/.config/fedorafig',
     help="" # TODO

--- a/src/main.py
+++ b/src/main.py
@@ -9,9 +9,6 @@ import cfg
 import help
 import errors
 
-# TODO: Check setting of configuration directory and __repos_do(),
-# if it sets the repos_done flag
-
 
 def main():
   """============================ MAIN PARSER ============================="""

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,9 @@ import cfg
 import help
 import errors
 
+# TODO: Check setting of configuration directory and __repos_do(),
+# if it sets the repos_done flag
+
 
 def main():
   """============================ MAIN PARSER ============================="""
@@ -113,6 +116,28 @@ def main():
     help="" # TODO
   )
 
+  """========================== UNINSTALL PARSER =========================="""
+  parser_uninstall = subparsers.add_parser(
+    'uninstall',
+    usage='', # TODO
+    help="" # TODO
+  )
+  parser_uninstall.set_defaults(func=uninstall)
+
+  parser_uninstall.add_argument(
+    '-s', '--with-state',
+    action='store_true',
+    default=False,
+    help="" # TODO
+  )
+
+  parser_uninstall.add_argument(
+    '-c', '--with-config',
+    action='store_true',
+    default=False,
+    help="" # TODO
+  )
+
   """============================= PARSE OPTS ============================="""
   try:
     args = vars(parser_main.parse_args())
@@ -142,6 +167,24 @@ def run(args):
   try: Run(args)
   except errors.FedorafigException as e: raise
   except (Exception, SystemExit) as e: errors.log(e); print(help.REPORT_ISSUE)
+
+
+def uninstall(args):
+  from subprocess import run
+
+  paths = [cfg.PROG_DIR, os.path.join(cfg.EXEC_DIR, 'fedorafig')]
+  if args['with_state']:
+    if os.path.isdir(cfg.STATE_DIR): paths.append(cfg.STATE_DIR)
+  if args['with_config']:
+    if os.path.isdir(cfg.CFG_DIR): paths.append(cfg.CFG_DIR)
+
+  print("Removing the following paths:")
+  for path in paths:
+    print(' ', path)
+
+  ans = input("Are you sure you want to proceed [y/N]: ")
+  if ans == 'Y' or ans == 'y':
+    for path in paths: run(['rm', '-rf', path], check=True)
 
 
 if __name__ == '__main__':

--- a/src/main.py
+++ b/src/main.py
@@ -1,262 +1,147 @@
 #!/bin/env python3
 
-# TODO: Write tests for everything
-# System packages
+# System imports
 import os
 import argparse
-import textwrap
-import fileinput
 
-# Local packages
+# Local imports
 import cfg
+import help
 import errors
-from check import Check
-from run import Run
 
 
-class MyArgumentParser(argparse.ArgumentParser):
-  parser_map = {}
-  mutually_excluded_groups = {}
-
-  def __init__(self, prog=None, *args, **kwargs):
-    super().__init__(prog, *args, **kwargs)
-
-    if prog in self.__class__.parser_map.keys():
-      raise Exception(f'Parser already exists for: {prog}')
-    elif prog == None:
-      return
-
-    self.name = prog
-    self.__class__.parser_map[self.name] = self
-
-
-  def error(self, msg):
-    super().error(textwrap.dedent(f"""
-      {msg}
-      Try '{self.name} --help' for more information.
-    """).strip())
-    exit(2)
-
-
-  @staticmethod
-  def custom_error(name, msg):
-    print(textwrap.dedent(f"""
-      {name}: error: {msg}
-      Try '{name} --help' for more information.
-    """).strip())
-    exit(2)
-
-  
-  def mutually_exclude_groups(self, *argparse_groups):
-    grouped_flags = []
-    for group in argparse_groups:
-      flags = [action.dest for action in group._group_actions]
-      grouped_flags.append(flags)
-    self.__class__.mutually_excluded_groups[self.name] = grouped_flags
-  
-
-  def parse_args(self, *args, **kwargs):
-    # `self.name` is different here, as we are using the top-level parser
-    args = super().parse_args(*args, **kwargs)
-    supergroups = self.mutually_excluded_groups
-
-    for parser_name, groups in supergroups.items():
-      matches = []
-      for group in groups:
-        try: vals = [getattr(args, flag) for flag in group]
-        except AttributeError: return args
-        matches.append(self.__list_disjunction(vals))
-      
-      collision_found = self.__list_conjunction(matches)
-      if collision_found:
-        # TODO: format the error message to display the flags
-        msg = 'arguments from mutually exclusive groups were used:'
-        self.__class__.parser_map[parser_name].error(msg)
-    
-    return args
-
-
-  def __list_disjunction(self, xs):
-    ret = False
-    for x in xs:
-      ret = ret or x
-    
-    return ret
-
-
-  def __list_conjunction(self, xs):
-    ret = True
-    for x in xs:
-      ret = ret and x
-    
-    return ret
-
-
-
-# TODO: Add examples, write help prompts
 def main():
-  parser = MyArgumentParser(
+  """============================ MAIN PARSER ============================="""
+  parser_main = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
     prog='fedorafig',
-    description=textwrap.dedent("""
-      CLI utility for Fedora Linux to configure your system from a JSON file.
-    """.strip()),
-    epilog=textwrap.dedent("""\
-    Find this project and its documentation on GitHub at:
-    https://github.com/amura-dev/fedorafig
-    """.strip())
+    description="", # TODO
+    epilog="" # TODO
   )
 
-  parser.add_argument(
-    '-f', '--new-cfg-dir',
-    type=set_cfg_dir,
-    help='set the config dir to something, and it will be this until set again'
+  parser_main.add_argument(
+    '-f', '--set-cfg-dir',
+    type=cfg.set_cfg_dir,
+    # default='~/.config/fedorafig',
+    help="" # TODO
   )
 
-  subparsers = parser.add_subparsers(
-    title='commands',
-    description="Main commands of the utility."
+  subparsers = parser_main.add_subparsers(
+    title='', # TODO
+    description="" # TODO
   )
 
+  """============================ CHECK PARSER ============================"""
   parser_check = subparsers.add_parser(
     'check',
-    usage='%(prog)s [-h] [-k] [-c, -s | -n] CFG_FILE_PATH'
+    usage='', # TODO
+    help="" # TODO
   )
-
-  yes_checksum = parser_check.add_argument_group('Use checksum')
-  no_checksum = parser_check.add_argument_group('Ignore checksum')
   parser_check.set_defaults(func=check)
 
   parser_check.add_argument(
     'CFG_FILE',
-    help=f'System configuration JSON file in {cfg.CFG_DIR}'
+    help="" # TODO
   )
 
   parser_check.add_argument(
     '-k', '--keep-checksums',
     action='store_true', 
     default=False,
-    help='something'
+    help="" # TODO
   )
-
-  yes_checksum.add_argument(
-    '-c',
-    '--only-checksum',
+  
+  parser_check.add_argument(
+    '-c', '--only-checksum',
     action='store_true',
-    default=False
+    default=False,
+    help="" # TODO
   )
 
-  yes_checksum.add_argument(
-    '-s',
-    '--show-checksum',
+  parser_check.add_argument(
+    '-s', '--show-checksum',
     action='store_true',
-    default=False
+    default=False,
+    help="" # TODO
   )
 
-  no_checksum.add_argument(
-    '-n',
-    '--no-checksum',
+  parser_check.add_argument(
+    '-n', '--no-checksum',
     action='store_true',
-    default=False
+    default=False,
+    help="" # TODO
   )
 
-
-  parser_check.mutually_exclude_groups(yes_checksum, no_checksum)
-  """
-  Group exclusion must be triggered after groups are initialised.
-  For changes to be reflected after adding arguments to group,
-  the mutual exclusion method must be called again.
-  """
-
+  """============================= RUN PARSER ============================="""
   parser_run = subparsers.add_parser(
-    'run'
+    'run',
+    usage='', # TODO
+    help="" # TODO
   )
-
   parser_run.set_defaults(func=run)
 
   parser_run.add_argument(
     'CFG_FILE',
-    help=f'System configuration JSON file in {cfg.CFG_DIR}'
+    help="" # TODO
   )
 
   parser_run.add_argument(
-    '-f',
-    '--files-include',
+    '-f', '--files-include',
     action='store_true',
-    default=False
+    default=False,
+    help="" # TODO
   )
 
   parser_run.add_argument(
-    '-p',
-    '--pkgs-include',
+    '-p', '--pkgs-include',
     action='store_true',
-    default=False
+    default=False,
+    help="" # TODO
   )
 
   parser_run.add_argument(
-    '-r',
-    '--repos-include',
+    '-r', '--repos-include',
     action='store_true',
-    default=False
+    default=False,
+    help="" # TODO
   )
 
   parser_run.add_argument(
-    '-s',
-    '--scripts-include',
+    '-s', '--scripts-include',
     action='store_true',
-    default=False
+    default=False,
+    help="" # TODO
   )
 
-  args = parser.parse_args()
+  """============================= PARSE OPTS ============================="""
+  try:
+    args = vars(parser_main.parse_args())
+  except errors.FedorafigException as e:
+    raise
+  except SystemExit as e:
+    if e.code == 0: return
+    raise errors.FedorafigException("Incorrect usage", exc=e)
+  except Exception as e:
+    errors.log(e); print(help.REPORT_ISSUE)
 
-  no_option = True
-  for val in vars(args).values():
-    if val != None:
-      no_option = False
-      break
-
-  if no_option:
-    parser.error("No arguments were provided")
-
-
-  try: args.func(args)
-  except AttributeError: pass
-
-
-def set_cfg_dir(arg):
-  fpath = cfg.getpath(arg)
-  if not(os.path.exists(fpath) and os.path.isdir(fpath)):
-    MyArgumentParser().custom_error('fedorafig',
-      f'argument -f/--new-cfg-dir: path does not exist or is not a \
-      directory: {fpath}'.replace('  ', ''))
-
-  cfg_path = cfg.getpath('~/.local/lib/fedorafig/cfg.py')
-  for line in fileinput.input(cfg_path, inplace=True):
-    if line.startswith('CFG_DIR_REL ='):
-      line_new = f"CFG_DIR_REL = '{fpath}'"
-      print(line_new)
-    else:
-      print(line, end='')
-
-  return arg
+  if not any(opt is not None for opt in args.values()):
+    raise errors.FedorafigException("No arguments")
+  
+  if 'func' in args and args['func'] is not None: args['func'](args)
 
 
 def check(args):
-  try:
-    Check(args)
-  except errors.CheckException as e:
-    MyArgumentParser.custom_error('fedorafig check', e)
-  except Exception as e:
-    raise Exception(e)
+  from check import Check
+  try: Check(args)
+  except errors.FedorafigException as e: raise
+  except (Exception, SystemExit) as e: errors.log(e); print(help.REPORT_ISSUE)
 
 
 def run(args):
-  try:
-    Run(args)
-  except errors.RunException as e:
-    MyArgumentParser.custom_error('fedorafig run', e)
-  except Exception as e:
-    raise Exception(e)
+  from run import Run
+  try: Run(args)
+  except errors.FedorafigException as e: raise
+  except (Exception, SystemExit) as e: errors.log(e); print(help.REPORT_ISSUE)
 
 
 if __name__ == '__main__':

--- a/src/run.py
+++ b/src/run.py
@@ -78,6 +78,8 @@ class Run():
         elif repo and not pkg: repos_cmd += [repo]
       subprocess.run(['sudo', 'dnf', 'config-manager', *repos_cmd], check=True)
 
+    self.repos_done = True
+
 
   def __pkgs_do(self):
     if not self.repos_done: self.__repos_do()

--- a/src/run.py
+++ b/src/run.py
@@ -12,7 +12,9 @@ import errors
 
 class Run():
   def __init__(self, args):
-    subprocess.run(['sudo', '-v'], check=True)
+    try: subprocess.run(['sudo', '-v'], check=True)
+    except subprocess.CalledProcessError as e: raise errors.FedorafigException(
+      "sudo timeout")
     sudo_refresh = threading.Thread(target=cfg.sudo_refresh, daemon=True)
     sudo_refresh.start()
 

--- a/test/cfgs/cfg1.json
+++ b/test/cfgs/cfg1.json
@@ -11,9 +11,13 @@
     "pkg": "htop"
   },
 
-  "repo only": {
-    "repo": "",
+  "repo must be accompanied by package": {
+    "repo": "mullvad-stable",
     "_COMMENT": "equivalent of adding a repo to be possibly used later"
+  },
+
+  "another repo": {
+    "repo": "rpmsphere"
   },
 
   "script only": {

--- a/test/cfgs/common/bye.sh
+++ b/test/cfgs/common/bye.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "GOOOODDDDBBAAAYEEEE"

--- a/test/cfgs/common/hello.sh
+++ b/test/cfgs/common/hello.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "HELLOOOOOOO"

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM fedora:40
 
 # Installing required packages.
 RUN dnf install -y \
+  dnf-plugins-core \
   python3 \
   ncurses \
   neovim \

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -30,5 +30,4 @@ RUN cd fedorafig && chmod u+x install.sh && ./install.sh
 RUN rm -rf fedorafig
 
 # Runs tests.
-# CMD ["/home/user/bin/fedorafig-src/test.sh"]
 CMD ["bash"]

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-trap 'exit' INT
-
-rm -rf ~/.config/fedorafig/ || true
-rm -rf ~/.local/state/fedorafig/ ~/.local/lib/fedorafig/ || true
-rm ~/.local/bin/fedorafig || true


### PR DESCRIPTION
- Code made more elegant.
- `uninstall` lets you uninstall `fedorafig` with itself.
- `exec` lets you run any script that sits in `$CFG_DIR/common`.
- Accounted for sudo timeout error.
- `check` seems runs faster as a result of using `dnf repoquery`, instead of `makecache`.
- `run` requires `config-manager` from `dnf-plguins-core` to permanently enabled repositories.